### PR TITLE
Impede erro de login duplicado (Duplicate Key) ao editar Professor e bugs relacionados ao usuario

### DIFF
--- a/src/main/java/br/edu/ifpb/pautax/application/useCases/administrador/professores/cadastrar/SalvarProfessorUseCase.java
+++ b/src/main/java/br/edu/ifpb/pautax/application/useCases/administrador/professores/cadastrar/SalvarProfessorUseCase.java
@@ -21,14 +21,7 @@ public class SalvarProfessorUseCase implements ISalvarProfessorUseCase {
     public String execute(Professor professor) {
         Usuario usuario = professor.getUsuario(); // Objeto vindo do formulário
 
-//        if (usuario.getId() > 0) {
-//            // É EDIÇÃO: Buscamos o usuário existente para obter o ID e a senha antiga.
-//            Usuario usuarioExistente = usuarioRepository.findById(usuario.getId())
-//                    .orElseThrow(() -> new RuntimeException("Usuário a ser editado não encontrado."));
-//            usuario.setId(usuarioExistente.getId());
-//        } else {
         usuario.setSenha(encoder.encode(usuario.getSenha()));
-        //}
 
         if (professor.isCoordenador()) {
             usuario.setRole(Set.of("ROLE_COORDENADOR"));

--- a/src/main/java/br/edu/ifpb/pautax/application/useCases/administrador/professores/cadastrar/SalvarProfessorUseCase.java
+++ b/src/main/java/br/edu/ifpb/pautax/application/useCases/administrador/professores/cadastrar/SalvarProfessorUseCase.java
@@ -1,7 +1,9 @@
 package br.edu.ifpb.pautax.application.useCases.administrador.professores.cadastrar;
 
 import br.edu.ifpb.pautax.domain.entities.Professor;
+import br.edu.ifpb.pautax.domain.entities.Usuario;
 import br.edu.ifpb.pautax.infrastructure.repositories.ProfessorRepository;
+import br.edu.ifpb.pautax.infrastructure.repositories.UsuarioRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -12,17 +14,32 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class SalvarProfessorUseCase implements ISalvarProfessorUseCase {
     private final ProfessorRepository professorRepository;
+    private final UsuarioRepository usuarioRepository;
     private final PasswordEncoder encoder;
 
     @Override
     public String execute(Professor professor) {
-        professor.setSenha(encoder.encode(professor.getSenha()));
+        Usuario usuario = professor.getUsuario(); // Objeto vindo do formulário
+
+//        if (usuario.getId() > 0) {
+//            // É EDIÇÃO: Buscamos o usuário existente para obter o ID e a senha antiga.
+//            Usuario usuarioExistente = usuarioRepository.findById(usuario.getId())
+//                    .orElseThrow(() -> new RuntimeException("Usuário a ser editado não encontrado."));
+//            usuario.setId(usuarioExistente.getId());
+//        } else {
+        usuario.setSenha(encoder.encode(usuario.getSenha()));
+        //}
+
         if (professor.isCoordenador()) {
-            professor.setRole(Set.of("ROLE_COORDENADOR"));
+            usuario.setRole(Set.of("ROLE_COORDENADOR"));
         } else {
-            professor.setRole(Set.of("ROLE_PROFESSOR"));
+            usuario.setRole(Set.of("ROLE_PROFESSOR"));
         }
+
+        usuarioRepository.save(usuario);
+
         professorRepository.save(professor);
+
         return "redirect:/admin/professores";
     }
 }

--- a/src/main/java/br/edu/ifpb/pautax/application/useCases/aluno/processo/CadastrarProcessoUseCase.java
+++ b/src/main/java/br/edu/ifpb/pautax/application/useCases/aluno/processo/CadastrarProcessoUseCase.java
@@ -33,7 +33,7 @@ public class CadastrarProcessoUseCase implements ICadastrarProcessoUseCase {
             processo.setRequerimento(arquivo.getBytes());
             processo.setStatusProcesso(StatusProcesso.CRIADO);
             processo.setNumero(gerarNumeroProcesso());
-            processo.setDataRecepcao(LocalDate.now());
+            processo.setDataRegistro(LocalDate.now());
 
             processoRepository.save(processo);
 

--- a/src/main/java/br/edu/ifpb/pautax/application/useCases/professor/processos/listar/ListarProcessosAtribuidosUseCase.java
+++ b/src/main/java/br/edu/ifpb/pautax/application/useCases/professor/processos/listar/ListarProcessosAtribuidosUseCase.java
@@ -2,6 +2,7 @@ package br.edu.ifpb.pautax.application.useCases.professor.processos.listar;
 
 import java.util.List;
 
+import br.edu.ifpb.pautax.infrastructure.repositories.ProfessorRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.ModelAndView;
 
@@ -16,11 +17,15 @@ import lombok.RequiredArgsConstructor;
 public class ListarProcessosAtribuidosUseCase implements IListarProcessosAtribuidosUseCase {
 
     private final ProcessoRepository processoRepository;
+    private final ProfessorRepository professorRepository;
 
     public ModelAndView execute(Usuario professorLogado) {
+        Professor professor = professorRepository.findByUsuario(professorLogado)
+                .orElseThrow(() -> new RuntimeException("Professor não encontrado."));;
+
         ModelAndView modelAndView = new ModelAndView("professor/meus-processos");
 
-        List<Processo> processos = processoRepository.findByRelator((Professor) professorLogado);
+        List<Processo> processos = processoRepository.findByRelator(professor);
 
         modelAndView.addObject("processosAtribuidos", processos);
 

--- a/src/main/java/br/edu/ifpb/pautax/domain/entities/Processo.java
+++ b/src/main/java/br/edu/ifpb/pautax/domain/entities/Processo.java
@@ -14,7 +14,7 @@ public class Processo {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
     private String numero;
-    private LocalDate dataRecepcao;
+    private LocalDate dataRegistro;
     private LocalDate dataDistribuicao;
     private LocalDate dataParecer;
 

--- a/src/main/java/br/edu/ifpb/pautax/domain/entities/Professor.java
+++ b/src/main/java/br/edu/ifpb/pautax/domain/entities/Professor.java
@@ -1,9 +1,6 @@
 package br.edu.ifpb.pautax.domain.entities;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.ManyToMany;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -11,12 +8,19 @@ import java.util.List;
 
 @Entity
 @Data
-@EqualsAndHashCode(callSuper = true)
-public class Professor extends Usuario{
+public class Professor {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+
     private boolean coordenador;
 
     @Column(nullable = false)
     private String matricula;
+
+    @OneToOne(cascade = CascadeType.REMOVE)
+    @JoinColumn(name = "usuario_id", nullable = false)
+    Usuario usuario;
 
     @ManyToMany(mappedBy = "membros")
     private List<Colegiado> colegiados;

--- a/src/main/java/br/edu/ifpb/pautax/infrastructure/repositories/ProfessorRepository.java
+++ b/src/main/java/br/edu/ifpb/pautax/infrastructure/repositories/ProfessorRepository.java
@@ -1,9 +1,14 @@
 package br.edu.ifpb.pautax.infrastructure.repositories;
 
+import br.edu.ifpb.pautax.domain.entities.Aluno;
 import br.edu.ifpb.pautax.domain.entities.Professor;
+import br.edu.ifpb.pautax.domain.entities.Usuario;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ProfessorRepository extends JpaRepository<Professor,Integer> {
+    Optional<Professor> findByUsuario(Usuario usuario);
 }

--- a/src/main/resources/templates/administrador/gerenciar-professores.html
+++ b/src/main/resources/templates/administrador/gerenciar-professores.html
@@ -11,24 +11,26 @@
 
     <input type="hidden" th:field="*{id}" />
 
+    <input type="hidden" th:field="*{usuario.id}" />
+
     <div>
         <label>Nome:</label>
-        <input type="text" th:field="*{nome}" placeholder="Digite o nome completo" required />
+        <input type="text" th:field="*{usuario.nome}" placeholder="Digite o nome completo" required />
     </div>
 
     <div>
         <label>Telefone:</label>
-        <input type="text" th:field="*{fone}" placeholder="(83) 99999-9999" />
+        <input type="text" th:field="*{usuario.fone}" placeholder="(83) 99999-9999" />
     </div>
 
     <div>
         <label>Login:</label>
-        <input type="text" th:field="*{login}" placeholder="ex: maria@ifpb.edu.br" required />
+        <input type="text" th:field="*{usuario.login}" placeholder="ex: maria@ifpb.edu.br" required />
     </div>
 
     <div>
         <label>Senha:</label>
-        <input type="password" th:field="*{senha}" placeholder="Digite uma senha" required />
+        <input type="password" th:field="*{usuario.senha}" placeholder="Digite uma senha" required />
     </div>
 
     <div>
@@ -65,10 +67,10 @@
     <tbody>
     <tr th:each="professor : ${listaDeProfessores}">
         <td th:text="${professor.id}"></td>
-        <td th:text="${professor.nome}"></td>
+        <td th:text="${professor.usuario.nome}"></td>
         <td th:text="${professor.matricula}"></td>
-        <td th:text="${professor.login}"></td>
-        <td th:text="${professor.fone}"></td>
+        <td th:text="${professor.usuario.login}"></td>
+        <td th:text="${professor.usuario.fone}"></td>
         <td th:text="${professor.coordenador} ? 'Sim' : 'Não'"></td>
         <td>
             <a th:href="@{/admin/professores/editar/{id}(id=${professor.id})}">


### PR DESCRIPTION
### Descrição

Este Pull Request (PR) corrige um erro crítico que impedia a atualização (edição) de registros de `Professor` e `Usuário`

#### 🐞 Bug Resolvido

Ao tentar salvar um Professor existente (`/admin/professores/salvar`), o sistema disparava o erro `DataIntegrityViolationException: duplicate key value violates unique constraint "uk_pm3f4m4fqv89oeeeac4tbe2f4"`, indicando que o login já existia.

#### 🔨 Causa Raiz

A causa era dupla:

1.  **Formulário:** O formulário de edição estava enviando o `Usuario` com `id=0` (conforme debug), pois o campo oculto `*{usuario.id}` estava ausente no HTML. Isso fazia com que o JPA interpretasse a ação como um **INSERT** (criação de novo usuário) em vez de um **UPDATE** (edição de usuário existente).