### PR TITLE
feat: Implementa consulta de reuniões do colegiado (REQFUNC 4)

### DIFF
--- a/src/main/java/br/edu/ifpb/pautax/api/coordenador/CoordenadorController.java
+++ b/src/main/java/br/edu/ifpb/pautax/api/coordenador/CoordenadorController.java
@@ -3,6 +3,7 @@ package br.edu.ifpb.pautax.api.coordenador;
 import br.edu.ifpb.pautax.application.useCases.coordenador.processo.distribuir.IDistribuirProcessoUseCase;
 import br.edu.ifpb.pautax.application.useCases.coordenador.processo.listarPendentes.IListarProcessosPendentesUseCase;
 import br.edu.ifpb.pautax.application.useCases.coordenador.processo.listarProcesso.IListarProcessosUseCase;
+import br.edu.ifpb.pautax.application.useCases.coordenador.reuniao.IListarReunioesUseCase;
 import br.edu.ifpb.pautax.application.useCases.coordenador.sessao.cadastrar.CriarSessaoFormDTO;
 import br.edu.ifpb.pautax.application.useCases.coordenador.sessao.cadastrar.ICriarSessaoUseCase;
 import br.edu.ifpb.pautax.application.useCases.coordenador.sessao.deletar.IDeletarSessaoUseCase;
@@ -11,6 +12,7 @@ import br.edu.ifpb.pautax.application.useCases.coordenador.sessao.listar.IListar
 import br.edu.ifpb.pautax.application.useCases.coordenador.sessao.mostrar.IMostrarSessaoUseCase;
 import br.edu.ifpb.pautax.application.useCases.coordenador.sessao.processo.mostrar.IMostrarProcessoSessaoUseCase;
 import br.edu.ifpb.pautax.domain.enums.StatusProcesso;
+import br.edu.ifpb.pautax.domain.enums.StatusReuniao;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -39,6 +41,7 @@ public class CoordenadorController {
     private final IIniciarSessaoUseCase iniciarSessaoUseCase;
     private final IMostrarSessaoUseCase mostrarSessaoUseCase;
     private final IMostrarProcessoSessaoUseCase mostrarProcessoSessaoUseCase;
+    private final IListarReunioesUseCase listarReunioesUseCase;
 
     @GetMapping("/home-coordenador")
     public ModelAndView mostrarHomeCoordenador() {
@@ -116,5 +119,19 @@ public class CoordenadorController {
     public ModelAndView mostrarProcessoDaSessao(@PathVariable("id") Integer idSessao,
                                                 @PathVariable("pid") Integer idProcesso) {
         return mostrarProcessoSessaoUseCase.execute(idSessao, idProcesso);
+    }
+
+    @GetMapping("/reunioes")
+    public ModelAndView consultarReunioes(@RequestParam(value = "status", required = false) StatusReuniao status) {
+        // Define qual página HTML vai abrir
+        ModelAndView mv = new ModelAndView("coordenador/consultar-reunioes");
+
+        // Adiciona a lista de reuniões (filtrada ou não)
+        mv.addObject("reunioes", listarReunioesUseCase.execute(status));
+
+        // Adiciona o status selecionado para manter o filtro marcado na tela
+        mv.addObject("statusSelecionado", status);
+
+        return mv;
     }
 }

--- a/src/main/java/br/edu/ifpb/pautax/api/coordenador/CoordenadorController.java
+++ b/src/main/java/br/edu/ifpb/pautax/api/coordenador/CoordenadorController.java
@@ -122,14 +122,10 @@ public class CoordenadorController {
     }
 
     @GetMapping("/reunioes")
-    public ModelAndView consultarReunioes(@RequestParam(value = "status", required = false) StatusReuniao status) {
-        // Define qual página HTML vai abrir
+    public ModelAndView consultarReunioes(@RequestParam(value = "status", required = false) StatusReuniao status) {        
         ModelAndView mv = new ModelAndView("coordenador/consultar-reunioes");
-
-        // Adiciona a lista de reuniões (filtrada ou não)
-        mv.addObject("reunioes", listarReunioesUseCase.execute(status));
-
-        // Adiciona o status selecionado para manter o filtro marcado na tela
+        
+        mv.addObject("reunioes", listarReunioesUseCase.execute(status));        
         mv.addObject("statusSelecionado", status);
 
         return mv;

--- a/src/main/java/br/edu/ifpb/pautax/application/useCases/coordenador/reuniao/IListarReunioesUseCase.java
+++ b/src/main/java/br/edu/ifpb/pautax/application/useCases/coordenador/reuniao/IListarReunioesUseCase.java
@@ -1,0 +1,10 @@
+package br.edu.ifpb.pautax.application.useCases.coordenador.reuniao;
+
+import java.util.List;
+
+import br.edu.ifpb.pautax.domain.entities.Reuniao;
+import br.edu.ifpb.pautax.domain.enums.StatusReuniao;
+
+public interface IListarReunioesUseCase {
+    List<Reuniao> execute(StatusReuniao status);
+}

--- a/src/main/java/br/edu/ifpb/pautax/application/useCases/coordenador/reuniao/ListarReunioesUseCase.java
+++ b/src/main/java/br/edu/ifpb/pautax/application/useCases/coordenador/reuniao/ListarReunioesUseCase.java
@@ -1,0 +1,33 @@
+package br.edu.ifpb.pautax.application.useCases.coordenador.reuniao;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import br.edu.ifpb.pautax.domain.entities.Reuniao;
+import br.edu.ifpb.pautax.domain.enums.StatusReuniao;
+import br.edu.ifpb.pautax.infrastructure.repositories.ReuniaoRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ListarReunioesUseCase implements IListarReunioesUseCase {
+    private final ReuniaoRepository reuniaoRepository;    
+
+    @Override    
+    @Transactional(readOnly = true)
+    public List<Reuniao> execute(StatusReuniao status) {
+        List<Reuniao> reunioes;
+
+        if (status == null) {
+            reunioes = reuniaoRepository.findByStatus(StatusReuniao.PROGRAMADA);
+        } else {
+            reunioes = reuniaoRepository.findByStatus(status);
+        }
+
+        reunioes.forEach(r -> r.getProcessos().size());
+
+        return reunioes;
+    }
+}

--- a/src/main/java/br/edu/ifpb/pautax/infrastructure/repositories/ReuniaoRepository.java
+++ b/src/main/java/br/edu/ifpb/pautax/infrastructure/repositories/ReuniaoRepository.java
@@ -2,8 +2,13 @@ package br.edu.ifpb.pautax.infrastructure.repositories;
 
 import br.edu.ifpb.pautax.domain.entities.Reuniao;
 import br.edu.ifpb.pautax.domain.enums.StatusReuniao;
+
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReuniaoRepository extends JpaRepository<Reuniao, Integer> {
     boolean existsByStatusAndIdNot(StatusReuniao status, Integer id);
+
+    List<Reuniao> findByStatus(StatusReuniao status);
 }

--- a/src/main/resources/templates/coordenador/consultar-reunioes.html
+++ b/src/main/resources/templates/coordenador/consultar-reunioes.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Consultar Reuniões</title>
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css">
+
+    <style>
+        a { text-decoration: none; }
+        a:hover { text-decoration: underline; }
+    </style>
+</head>
+<body class="bg-light">
+
+<div class="container mt-5">
+
+    <h1 class="mb-4">Consultar Reuniões do Colegiado</h1>
+
+    <div class="card shadow p-4 mb-5">
+        
+        <h3 class="mb-3">Filtrar Reuniões</h3>
+        
+        <form method="get" action="/coordenador/reunioes" class="row g-3 align-items-end">
+            <div class="col-md-5">
+                <label for="status" class="form-label fw-bold">Situação:</label>
+                <select name="status" id="status" class="form-select">
+                    <option value="">Todas as Reuniões</option>
+                    <option value="PROGRAMADA" th:selected="${statusSelecionado != null && statusSelecionado.name() == 'PROGRAMADA'}">Agendada</option>
+                    <option value="ENCERRADA" th:selected="${statusSelecionado != null && statusSelecionado.name() == 'ENCERRADA'}">Finalizada</option>
+                    <option value="INICIADA" th:selected="${statusSelecionado != null && statusSelecionado.name() == 'INICIADA'}">Em Andamento</option>
+                </select>
+            </div>
+            <div class="col-md-2">
+                <button type="submit" class="btn btn-primary w-100">
+                    <i class="bi bi-search"></i> Filtrar
+                </button>
+            </div>
+        </form>
+
+        <hr class="my-4">
+
+        <h3 class="mb-3">Listagem de Reuniões</h3>
+
+        <div th:if="${#lists.isEmpty(reunioes)}" class="alert alert-warning text-center">
+            <i class="bi bi-info-circle"></i> Nenhuma reunião encontrada com este filtro.
+        </div>
+
+        <div th:unless="${#lists.isEmpty(reunioes)}" class="table-responsive">
+            <table class="table table-striped table-hover align-middle border">
+                <thead class="table-dark">
+                    <tr>
+                        <th>Data e Hora</th>
+                        <th>Colegiado</th>
+                        <th>Status</th>
+                        <th>Pauta (Processos)</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr th:each="reuniao : ${reunioes}">
+                        <td th:text="${#dates.format(reuniao.dataReuniao, 'dd/MM/yyyy HH:mm')}"></td>
+                        
+                        <td th:text="${reuniao.colegiado.descricao}">Colegiado TSI</td>
+                        
+                        <td>
+                            <span class="badge" 
+                                  th:classappend="${reuniao.status.name() == 'PROGRAMADA'} ? 'bg-primary' : 
+                                                  (${reuniao.status.name() == 'ENCERRADA'} ? 'bg-secondary' : 'bg-success')"
+                                  th:text="${reuniao.status}">
+                            </span>
+                        </td>
+                        
+                        <td>
+                            <details th:if="${not #lists.isEmpty(reuniao.processos)}">
+                                <summary class="fw-bold text-primary" style="cursor:pointer;">
+                                    <span th:text="${#lists.size(reuniao.processos)} + ' processos'"></span>
+                                </summary>
+                                <ul class="mt-2 small list-unstyled border rounded p-2 bg-white">
+                                    <li th:each="proc : ${reuniao.processos}" class="mb-1 border-bottom pb-1">
+                                        <i class="bi bi-file-earmark-text"></i> 
+                                        <strong th:text="${'Nº ' + proc.numero}"></strong> 
+                                        <br>
+                                        <span class="text-muted" th:text="${proc.assunto.nome}"></span>
+                                    </li>
+                                </ul>
+                            </details>
+                            
+                            <span th:if="${#lists.isEmpty(reuniao.processos)}" class="text-muted fst-italic">
+                                Sem processos na pauta
+                            </span>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+
+    <a th:href="@{/coordenador/home-coordenador}" class="btn btn-secondary mb-5">
+        Voltar ao Painel
+    </a>
+
+</div>
+
+</body>
+</html>

--- a/src/main/resources/templates/coordenador/home-coordenador.html
+++ b/src/main/resources/templates/coordenador/home-coordenador.html
@@ -41,6 +41,11 @@
                     Gerenciar sessões de colegiados
                 </a>
             </li>
+            <li class="list-group-item">
+                <a th:href="@{/coordenador/reunioes}" class="fw-bold text-primary">
+                    Consultar Reuniões do Colegiado
+                </a>
+            </li>
         </ul>
     </div>
 


### PR DESCRIPTION
📝 Resumo
Este PR implementa o Requisito Funcional 4, permitindo que o Coordenador consulte todas as reuniões do colegiado (agendadas, finalizadas ou em andamento). A funcionalidade inclui um filtro por status e a visualização dos processos em pauta.

🛠️ Alterações Realizadas
Backend:

UseCase: Criação do ListarReunioesUseCase para buscar reuniões no banco.

Implementada lógica para carregar processos (pauta) dentro do escopo transacional (@Transactional) para evitar erros de Large Objects (LOBs) com PostgreSQL/Hibernate.

Repository: Adição do método findByStatus no ReuniaoRepository.

Controller: Adição do endpoint /coordenador/reunioes no CoordenadorController para gerenciar a requisição e o filtro.

Frontend (Thymeleaf):

Nova Tela: Criação do template coordenador/consultar-reunioes.html.

Tabela padronizada com Bootstrap.

Badge de status colorido dinamicamente.

Uso da tag <details> para exibir a lista de processos da pauta de forma expansível.

Correção na formatação de datas (uso de #dates para compatibilidade com Timestamp).

Menu: Adição do link "Consultar Reuniões" na home-coordenador.html.

🧪 Como Testar
Faça login com um usuário Coordenador.

No painel inicial, clique em "Consultar Reuniões do Colegiado".

Verifique a listagem das reuniões.

Utilize o filtro "Situação" para alternar entre Agendada, Finalizada, etc.

Clique no texto "X processos" na coluna Pauta para expandir e ver os detalhes dos processos vinculados.